### PR TITLE
Fix double whitespace.

### DIFF
--- a/src/main/render/apache/service/processor.ts
+++ b/src/main/render/apache/service/processor.ts
@@ -581,7 +581,7 @@ function createElseForExceptions(
                 // console.error('Unexpected exception...', err)
                 createMethodCallStatement(COMMON_IDENTIFIERS.console, 'error', [
                     ts.createLiteral(
-                        `Unexpected exception while handling ${funcDef.name.value}: `,
+                        `Unexpected exception while handling ${funcDef.name.value}:`,
                     ),
                     COMMON_IDENTIFIERS.err,
                 ]),
@@ -731,7 +731,7 @@ function createExceptionHandlers(
             // console.error('Unexpected exception...', err)
             createMethodCallStatement(COMMON_IDENTIFIERS.console, 'error', [
                 ts.createLiteral(
-                    `Unexpected exception while handling ${funcDef.name.value}: `,
+                    `Unexpected exception while handling ${funcDef.name.value}:`,
                 ),
                 COMMON_IDENTIFIERS.err,
             ]),

--- a/src/main/render/thrift-server/service/processor.ts
+++ b/src/main/render/thrift-server/service/processor.ts
@@ -539,7 +539,7 @@ function createElseForExceptions(
                 // console.error('Unexpected exception...', err)
                 createMethodCallStatement(COMMON_IDENTIFIERS.console, 'error', [
                     ts.createLiteral(
-                        `Unexpected exception while handling ${funcDef.name.value}: `,
+                        `Unexpected exception while handling ${funcDef.name.value}:`,
                     ),
                     COMMON_IDENTIFIERS.err,
                 ]),
@@ -689,7 +689,7 @@ function createExceptionHandlers(
             // console.error('Unexpected exception...', err)
             createMethodCallStatement(COMMON_IDENTIFIERS.console, 'error', [
                 ts.createLiteral(
-                    `Unexpected exception while handling ${funcDef.name.value}: `,
+                    `Unexpected exception while handling ${funcDef.name.value}:`,
                 ),
                 COMMON_IDENTIFIERS.err,
             ]),

--- a/src/tests/unit/fixtures/apache/basic_service.solution.ts
+++ b/src/tests/unit/fixtures/apache/basic_service.solution.ts
@@ -177,7 +177,7 @@ export class Processor {
             output.flush();
             return;
         }).catch((err: Error): void => {
-            console.error("Unexpected exception while handling ping: ", err);
+            console.error("Unexpected exception while handling ping:", err);
             const result: thrift.Thrift.TApplicationException = new thrift.Thrift.TApplicationException(thrift.Thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("ping", thrift.Thrift.MessageType.EXCEPTION, requestId);
             result.write(output);

--- a/src/tests/unit/fixtures/apache/generated/SharedService.ts
+++ b/src/tests/unit/fixtures/apache/generated/SharedService.ts
@@ -368,7 +368,7 @@ export class Processor extends SharedServiceBase.Processor {
             output.flush();
             return;
         }).catch((err: Error): void => {
-            console.error("Unexpected exception while handling getUnion: ", err);
+            console.error("Unexpected exception while handling getUnion:", err);
             const result: thrift.Thrift.TApplicationException = new thrift.Thrift.TApplicationException(thrift.Thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("getUnion", thrift.Thrift.MessageType.EXCEPTION, requestId);
             result.write(output);
@@ -394,7 +394,7 @@ export class Processor extends SharedServiceBase.Processor {
             output.flush();
             return;
         }).catch((err: Error): void => {
-            console.error("Unexpected exception while handling getEnum: ", err);
+            console.error("Unexpected exception while handling getEnum:", err);
             const result: thrift.Thrift.TApplicationException = new thrift.Thrift.TApplicationException(thrift.Thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("getEnum", thrift.Thrift.MessageType.EXCEPTION, requestId);
             result.write(output);

--- a/src/tests/unit/fixtures/apache/generated/SharedServiceBase.ts
+++ b/src/tests/unit/fixtures/apache/generated/SharedServiceBase.ts
@@ -226,7 +226,7 @@ export class Processor {
             output.flush();
             return;
         }).catch((err: Error): void => {
-            console.error("Unexpected exception while handling getStruct: ", err);
+            console.error("Unexpected exception while handling getStruct:", err);
             const result: thrift.Thrift.TApplicationException = new thrift.Thrift.TApplicationException(thrift.Thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("getStruct", thrift.Thrift.MessageType.EXCEPTION, requestId);
             result.write(output);

--- a/src/tests/unit/fixtures/apache/generated/com/test/calculator/Calculator.ts
+++ b/src/tests/unit/fixtures/apache/generated/com/test/calculator/Calculator.ts
@@ -2603,7 +2603,7 @@ export class Processor extends __ROOT_NAMESPACE__.SharedService.Processor {
             output.flush();
             return;
         }).catch((err: Error): void => {
-            console.error("Unexpected exception while handling ping: ", err);
+            console.error("Unexpected exception while handling ping:", err);
             const result: thrift.Thrift.TApplicationException = new thrift.Thrift.TApplicationException(thrift.Thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("ping", thrift.Thrift.MessageType.EXCEPTION, requestId);
             result.write(output);
@@ -2639,7 +2639,7 @@ export class Processor extends __ROOT_NAMESPACE__.SharedService.Processor {
                 return;
             }
             else {
-                console.error("Unexpected exception while handling add: ", err);
+                console.error("Unexpected exception while handling add:", err);
                 const result: thrift.Thrift.TApplicationException = new thrift.Thrift.TApplicationException(thrift.Thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
                 output.writeMessageBegin("add", thrift.Thrift.MessageType.EXCEPTION, requestId);
                 result.write(output);
@@ -2676,7 +2676,7 @@ export class Processor extends __ROOT_NAMESPACE__.SharedService.Processor {
                 return;
             }
             else {
-                console.error("Unexpected exception while handling addInt64: ", err);
+                console.error("Unexpected exception while handling addInt64:", err);
                 const result: thrift.Thrift.TApplicationException = new thrift.Thrift.TApplicationException(thrift.Thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
                 output.writeMessageBegin("addInt64", thrift.Thrift.MessageType.EXCEPTION, requestId);
                 result.write(output);
@@ -2704,7 +2704,7 @@ export class Processor extends __ROOT_NAMESPACE__.SharedService.Processor {
             output.flush();
             return;
         }).catch((err: Error): void => {
-            console.error("Unexpected exception while handling addWithContext: ", err);
+            console.error("Unexpected exception while handling addWithContext:", err);
             const result: thrift.Thrift.TApplicationException = new thrift.Thrift.TApplicationException(thrift.Thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("addWithContext", thrift.Thrift.MessageType.EXCEPTION, requestId);
             result.write(output);
@@ -2740,7 +2740,7 @@ export class Processor extends __ROOT_NAMESPACE__.SharedService.Processor {
                 return;
             }
             else {
-                console.error("Unexpected exception while handling calculate: ", err);
+                console.error("Unexpected exception while handling calculate:", err);
                 const result: thrift.Thrift.TApplicationException = new thrift.Thrift.TApplicationException(thrift.Thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
                 output.writeMessageBegin("calculate", thrift.Thrift.MessageType.EXCEPTION, requestId);
                 result.write(output);
@@ -2768,7 +2768,7 @@ export class Processor extends __ROOT_NAMESPACE__.SharedService.Processor {
             output.flush();
             return;
         }).catch((err: Error): void => {
-            console.error("Unexpected exception while handling echoBinary: ", err);
+            console.error("Unexpected exception while handling echoBinary:", err);
             const result: thrift.Thrift.TApplicationException = new thrift.Thrift.TApplicationException(thrift.Thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("echoBinary", thrift.Thrift.MessageType.EXCEPTION, requestId);
             result.write(output);
@@ -2795,7 +2795,7 @@ export class Processor extends __ROOT_NAMESPACE__.SharedService.Processor {
             output.flush();
             return;
         }).catch((err: Error): void => {
-            console.error("Unexpected exception while handling echoString: ", err);
+            console.error("Unexpected exception while handling echoString:", err);
             const result: thrift.Thrift.TApplicationException = new thrift.Thrift.TApplicationException(thrift.Thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("echoString", thrift.Thrift.MessageType.EXCEPTION, requestId);
             result.write(output);
@@ -2822,7 +2822,7 @@ export class Processor extends __ROOT_NAMESPACE__.SharedService.Processor {
             output.flush();
             return;
         }).catch((err: Error): void => {
-            console.error("Unexpected exception while handling checkName: ", err);
+            console.error("Unexpected exception while handling checkName:", err);
             const result: thrift.Thrift.TApplicationException = new thrift.Thrift.TApplicationException(thrift.Thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("checkName", thrift.Thrift.MessageType.EXCEPTION, requestId);
             result.write(output);
@@ -2849,7 +2849,7 @@ export class Processor extends __ROOT_NAMESPACE__.SharedService.Processor {
             output.flush();
             return;
         }).catch((err: Error): void => {
-            console.error("Unexpected exception while handling checkOptional: ", err);
+            console.error("Unexpected exception while handling checkOptional:", err);
             const result: thrift.Thrift.TApplicationException = new thrift.Thrift.TApplicationException(thrift.Thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("checkOptional", thrift.Thrift.MessageType.EXCEPTION, requestId);
             result.write(output);
@@ -2876,7 +2876,7 @@ export class Processor extends __ROOT_NAMESPACE__.SharedService.Processor {
             output.flush();
             return;
         }).catch((err: Error): void => {
-            console.error("Unexpected exception while handling mapOneList: ", err);
+            console.error("Unexpected exception while handling mapOneList:", err);
             const result: thrift.Thrift.TApplicationException = new thrift.Thrift.TApplicationException(thrift.Thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("mapOneList", thrift.Thrift.MessageType.EXCEPTION, requestId);
             result.write(output);
@@ -2903,7 +2903,7 @@ export class Processor extends __ROOT_NAMESPACE__.SharedService.Processor {
             output.flush();
             return;
         }).catch((err: Error): void => {
-            console.error("Unexpected exception while handling mapValues: ", err);
+            console.error("Unexpected exception while handling mapValues:", err);
             const result: thrift.Thrift.TApplicationException = new thrift.Thrift.TApplicationException(thrift.Thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("mapValues", thrift.Thrift.MessageType.EXCEPTION, requestId);
             result.write(output);
@@ -2930,7 +2930,7 @@ export class Processor extends __ROOT_NAMESPACE__.SharedService.Processor {
             output.flush();
             return;
         }).catch((err: Error): void => {
-            console.error("Unexpected exception while handling listToMap: ", err);
+            console.error("Unexpected exception while handling listToMap:", err);
             const result: thrift.Thrift.TApplicationException = new thrift.Thrift.TApplicationException(thrift.Thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("listToMap", thrift.Thrift.MessageType.EXCEPTION, requestId);
             result.write(output);
@@ -2956,7 +2956,7 @@ export class Processor extends __ROOT_NAMESPACE__.SharedService.Processor {
             output.flush();
             return;
         }).catch((err: Error): void => {
-            console.error("Unexpected exception while handling fetchThing: ", err);
+            console.error("Unexpected exception while handling fetchThing:", err);
             const result: thrift.Thrift.TApplicationException = new thrift.Thrift.TApplicationException(thrift.Thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("fetchThing", thrift.Thrift.MessageType.EXCEPTION, requestId);
             result.write(output);
@@ -2982,7 +2982,7 @@ export class Processor extends __ROOT_NAMESPACE__.SharedService.Processor {
             output.flush();
             return;
         }).catch((err: Error): void => {
-            console.error("Unexpected exception while handling fetchMap: ", err);
+            console.error("Unexpected exception while handling fetchMap:", err);
             const result: thrift.Thrift.TApplicationException = new thrift.Thrift.TApplicationException(thrift.Thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("fetchMap", thrift.Thrift.MessageType.EXCEPTION, requestId);
             result.write(output);
@@ -3008,7 +3008,7 @@ export class Processor extends __ROOT_NAMESPACE__.SharedService.Processor {
             output.flush();
             return;
         }).catch((err: Error): void => {
-            console.error("Unexpected exception while handling zip: ", err);
+            console.error("Unexpected exception while handling zip:", err);
             const result: thrift.Thrift.TApplicationException = new thrift.Thrift.TApplicationException(thrift.Thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("zip", thrift.Thrift.MessageType.EXCEPTION, requestId);
             result.write(output);

--- a/src/tests/unit/fixtures/apache/i64_service.solution.ts
+++ b/src/tests/unit/fixtures/apache/i64_service.solution.ts
@@ -255,7 +255,7 @@ export class Processor {
             output.flush();
             return;
         }).catch((err: Error): void => {
-            console.error("Unexpected exception while handling add: ", err);
+            console.error("Unexpected exception while handling add:", err);
             const result: thrift.Thrift.TApplicationException = new thrift.Thrift.TApplicationException(thrift.Thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("add", thrift.Thrift.MessageType.EXCEPTION, requestId);
             result.write(output);

--- a/src/tests/unit/fixtures/apache/return_service.solution.ts
+++ b/src/tests/unit/fixtures/apache/return_service.solution.ts
@@ -302,7 +302,7 @@ export class Processor {
                 return;
             }
             else {
-                console.error("Unexpected exception while handling ping: ", err);
+                console.error("Unexpected exception while handling ping:", err);
                 const result: thrift.Thrift.TApplicationException = new thrift.Thrift.TApplicationException(thrift.Thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
                 output.writeMessageBegin("ping", thrift.Thrift.MessageType.EXCEPTION, requestId);
                 result.write(output);

--- a/src/tests/unit/fixtures/apache/throws_multi_service.solution.ts
+++ b/src/tests/unit/fixtures/apache/throws_multi_service.solution.ts
@@ -483,7 +483,7 @@ export class Processor {
                 return;
             }
             else {
-                console.error("Unexpected exception while handling peg: ", err);
+                console.error("Unexpected exception while handling peg:", err);
                 const result: thrift.Thrift.TApplicationException = new thrift.Thrift.TApplicationException(thrift.Thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
                 output.writeMessageBegin("peg", thrift.Thrift.MessageType.EXCEPTION, requestId);
                 result.write(output);

--- a/src/tests/unit/fixtures/apache/throws_service.solution.ts
+++ b/src/tests/unit/fixtures/apache/throws_service.solution.ts
@@ -262,7 +262,7 @@ export class Processor {
                 return;
             }
             else {
-                console.error("Unexpected exception while handling ping: ", err);
+                console.error("Unexpected exception while handling ping:", err);
                 const result: thrift.Thrift.TApplicationException = new thrift.Thrift.TApplicationException(thrift.Thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
                 output.writeMessageBegin("ping", thrift.Thrift.MessageType.EXCEPTION, requestId);
                 result.write(output);

--- a/src/tests/unit/fixtures/thrift-server/annotations_service.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/annotations_service.solution.ts
@@ -777,7 +777,7 @@ export class Processor<Context = any> extends thrift.ThriftProcessor<Context, IH
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
-            console.error("Unexpected exception while handling getUser: ", err);
+            console.error("Unexpected exception while handling getUser:", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("getUser", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -802,7 +802,7 @@ export class Processor<Context = any> extends thrift.ThriftProcessor<Context, IH
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
-            console.error("Unexpected exception while handling saveUser: ", err);
+            console.error("Unexpected exception while handling saveUser:", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("saveUser", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -826,7 +826,7 @@ export class Processor<Context = any> extends thrift.ThriftProcessor<Context, IH
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
-            console.error("Unexpected exception while handling ping: ", err);
+            console.error("Unexpected exception while handling ping:", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("ping", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);

--- a/src/tests/unit/fixtures/thrift-server/basic_service.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/basic_service.solution.ts
@@ -765,7 +765,7 @@ export class Processor<Context = any> extends thrift.ThriftProcessor<Context, IH
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
-            console.error("Unexpected exception while handling getUser: ", err);
+            console.error("Unexpected exception while handling getUser:", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("getUser", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -790,7 +790,7 @@ export class Processor<Context = any> extends thrift.ThriftProcessor<Context, IH
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
-            console.error("Unexpected exception while handling saveUser: ", err);
+            console.error("Unexpected exception while handling saveUser:", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("saveUser", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -814,7 +814,7 @@ export class Processor<Context = any> extends thrift.ThriftProcessor<Context, IH
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
-            console.error("Unexpected exception while handling ping: ", err);
+            console.error("Unexpected exception while handling ping:", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("ping", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);

--- a/src/tests/unit/fixtures/thrift-server/basic_service.strict_union.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/basic_service.strict_union.solution.ts
@@ -610,7 +610,7 @@ export class Processor<Context = any> extends thrift.ThriftProcessor<Context, IH
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
-            console.error("Unexpected exception while handling getUser: ", err);
+            console.error("Unexpected exception while handling getUser:", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("getUser", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -634,7 +634,7 @@ export class Processor<Context = any> extends thrift.ThriftProcessor<Context, IH
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
-            console.error("Unexpected exception while handling ping: ", err);
+            console.error("Unexpected exception while handling ping:", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("ping", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);

--- a/src/tests/unit/fixtures/thrift-server/generated-strict/SharedService.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated-strict/SharedService.ts
@@ -488,7 +488,7 @@ export class Processor<Context = any> extends SharedServiceBase.Processor<Contex
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
-            console.error("Unexpected exception while handling getUnion: ", err);
+            console.error("Unexpected exception while handling getUnion:", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("getUnion", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -512,7 +512,7 @@ export class Processor<Context = any> extends SharedServiceBase.Processor<Contex
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
-            console.error("Unexpected exception while handling getEnum: ", err);
+            console.error("Unexpected exception while handling getEnum:", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("getEnum", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);

--- a/src/tests/unit/fixtures/thrift-server/generated-strict/SharedServiceBase.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated-strict/SharedServiceBase.ts
@@ -295,7 +295,7 @@ export class Processor<Context = any> extends thrift.ThriftProcessor<Context, IH
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
-            console.error("Unexpected exception while handling getStruct: ", err);
+            console.error("Unexpected exception while handling getStruct:", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("getStruct", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);

--- a/src/tests/unit/fixtures/thrift-server/generated-strict/com/test/calculator/Calculator.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated-strict/com/test/calculator/Calculator.ts
@@ -3453,7 +3453,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
-            console.error("Unexpected exception while handling ping: ", err);
+            console.error("Unexpected exception while handling ping:", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("ping", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3486,7 +3486,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
                 return output.flush();
             }
             else {
-                console.error("Unexpected exception while handling add: ", err);
+                console.error("Unexpected exception while handling add:", err);
                 const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
                 output.writeMessageBegin("add", thrift.MessageType.EXCEPTION, requestId);
                 thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3520,7 +3520,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
                 return output.flush();
             }
             else {
-                console.error("Unexpected exception while handling addInt64: ", err);
+                console.error("Unexpected exception while handling addInt64:", err);
                 const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
                 output.writeMessageBegin("addInt64", thrift.MessageType.EXCEPTION, requestId);
                 thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3546,7 +3546,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
-            console.error("Unexpected exception while handling addWithContext: ", err);
+            console.error("Unexpected exception while handling addWithContext:", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("addWithContext", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3579,7 +3579,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
                 return output.flush();
             }
             else {
-                console.error("Unexpected exception while handling calculate: ", err);
+                console.error("Unexpected exception while handling calculate:", err);
                 const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
                 output.writeMessageBegin("calculate", thrift.MessageType.EXCEPTION, requestId);
                 thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3605,7 +3605,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
-            console.error("Unexpected exception while handling echoBinary: ", err);
+            console.error("Unexpected exception while handling echoBinary:", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("echoBinary", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3630,7 +3630,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
-            console.error("Unexpected exception while handling echoString: ", err);
+            console.error("Unexpected exception while handling echoString:", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("echoString", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3655,7 +3655,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
-            console.error("Unexpected exception while handling checkName: ", err);
+            console.error("Unexpected exception while handling checkName:", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("checkName", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3680,7 +3680,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
-            console.error("Unexpected exception while handling checkOptional: ", err);
+            console.error("Unexpected exception while handling checkOptional:", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("checkOptional", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3705,7 +3705,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
-            console.error("Unexpected exception while handling mapOneList: ", err);
+            console.error("Unexpected exception while handling mapOneList:", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("mapOneList", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3730,7 +3730,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
-            console.error("Unexpected exception while handling mapValues: ", err);
+            console.error("Unexpected exception while handling mapValues:", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("mapValues", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3755,7 +3755,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
-            console.error("Unexpected exception while handling listToMap: ", err);
+            console.error("Unexpected exception while handling listToMap:", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("listToMap", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3779,7 +3779,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
-            console.error("Unexpected exception while handling fetchThing: ", err);
+            console.error("Unexpected exception while handling fetchThing:", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("fetchThing", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3803,7 +3803,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
-            console.error("Unexpected exception while handling fetchMap: ", err);
+            console.error("Unexpected exception while handling fetchMap:", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("fetchMap", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3827,7 +3827,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
-            console.error("Unexpected exception while handling zip: ", err);
+            console.error("Unexpected exception while handling zip:", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("zip", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);

--- a/src/tests/unit/fixtures/thrift-server/generated/SharedService.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated/SharedService.ts
@@ -488,7 +488,7 @@ export class Processor<Context = any> extends SharedServiceBase.Processor<Contex
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
-            console.error("Unexpected exception while handling getUnion: ", err);
+            console.error("Unexpected exception while handling getUnion:", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("getUnion", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -512,7 +512,7 @@ export class Processor<Context = any> extends SharedServiceBase.Processor<Contex
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
-            console.error("Unexpected exception while handling getEnum: ", err);
+            console.error("Unexpected exception while handling getEnum:", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("getEnum", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);

--- a/src/tests/unit/fixtures/thrift-server/generated/SharedServiceBase.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated/SharedServiceBase.ts
@@ -295,7 +295,7 @@ export class Processor<Context = any> extends thrift.ThriftProcessor<Context, IH
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
-            console.error("Unexpected exception while handling getStruct: ", err);
+            console.error("Unexpected exception while handling getStruct:", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("getStruct", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);

--- a/src/tests/unit/fixtures/thrift-server/generated/com/test/calculator/Calculator.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated/com/test/calculator/Calculator.ts
@@ -3453,7 +3453,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
-            console.error("Unexpected exception while handling ping: ", err);
+            console.error("Unexpected exception while handling ping:", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("ping", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3486,7 +3486,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
                 return output.flush();
             }
             else {
-                console.error("Unexpected exception while handling add: ", err);
+                console.error("Unexpected exception while handling add:", err);
                 const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
                 output.writeMessageBegin("add", thrift.MessageType.EXCEPTION, requestId);
                 thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3520,7 +3520,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
                 return output.flush();
             }
             else {
-                console.error("Unexpected exception while handling addInt64: ", err);
+                console.error("Unexpected exception while handling addInt64:", err);
                 const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
                 output.writeMessageBegin("addInt64", thrift.MessageType.EXCEPTION, requestId);
                 thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3546,7 +3546,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
-            console.error("Unexpected exception while handling addWithContext: ", err);
+            console.error("Unexpected exception while handling addWithContext:", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("addWithContext", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3579,7 +3579,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
                 return output.flush();
             }
             else {
-                console.error("Unexpected exception while handling calculate: ", err);
+                console.error("Unexpected exception while handling calculate:", err);
                 const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
                 output.writeMessageBegin("calculate", thrift.MessageType.EXCEPTION, requestId);
                 thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3605,7 +3605,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
-            console.error("Unexpected exception while handling echoBinary: ", err);
+            console.error("Unexpected exception while handling echoBinary:", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("echoBinary", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3630,7 +3630,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
-            console.error("Unexpected exception while handling echoString: ", err);
+            console.error("Unexpected exception while handling echoString:", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("echoString", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3655,7 +3655,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
-            console.error("Unexpected exception while handling checkName: ", err);
+            console.error("Unexpected exception while handling checkName:", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("checkName", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3680,7 +3680,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
-            console.error("Unexpected exception while handling checkOptional: ", err);
+            console.error("Unexpected exception while handling checkOptional:", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("checkOptional", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3705,7 +3705,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
-            console.error("Unexpected exception while handling mapOneList: ", err);
+            console.error("Unexpected exception while handling mapOneList:", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("mapOneList", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3730,7 +3730,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
-            console.error("Unexpected exception while handling mapValues: ", err);
+            console.error("Unexpected exception while handling mapValues:", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("mapValues", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3755,7 +3755,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
-            console.error("Unexpected exception while handling listToMap: ", err);
+            console.error("Unexpected exception while handling listToMap:", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("listToMap", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3779,7 +3779,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
-            console.error("Unexpected exception while handling fetchThing: ", err);
+            console.error("Unexpected exception while handling fetchThing:", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("fetchThing", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3803,7 +3803,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
-            console.error("Unexpected exception while handling fetchMap: ", err);
+            console.error("Unexpected exception while handling fetchMap:", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("fetchMap", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3827,7 +3827,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
-            console.error("Unexpected exception while handling zip: ", err);
+            console.error("Unexpected exception while handling zip:", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("zip", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);

--- a/src/tests/unit/fixtures/thrift-server/i64_service.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/i64_service.solution.ts
@@ -566,7 +566,7 @@ export class Processor<Context = any> extends thrift.ThriftProcessor<Context, IH
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
-            console.error("Unexpected exception while handling peg: ", err);
+            console.error("Unexpected exception while handling peg:", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("peg", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -591,7 +591,7 @@ export class Processor<Context = any> extends thrift.ThriftProcessor<Context, IH
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
-            console.error("Unexpected exception while handling pong: ", err);
+            console.error("Unexpected exception while handling pong:", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("pong", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);

--- a/src/tests/unit/fixtures/thrift-server/resolved_field_service.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/resolved_field_service.solution.ts
@@ -274,7 +274,7 @@ export class Processor<Context = any> extends thrift.ThriftProcessor<Context, IH
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
-            console.error("Unexpected exception while handling ping: ", err);
+            console.error("Unexpected exception while handling ping:", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("ping", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);

--- a/src/tests/unit/fixtures/thrift-server/throws_multi_service.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/throws_multi_service.solution.ts
@@ -641,7 +641,7 @@ export class Processor<Context = any> extends thrift.ThriftProcessor<Context, IH
                 return output.flush();
             }
             else {
-                console.error("Unexpected exception while handling peg: ", err);
+                console.error("Unexpected exception while handling peg:", err);
                 const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
                 output.writeMessageBegin("peg", thrift.MessageType.EXCEPTION, requestId);
                 thrift.TApplicationExceptionCodec.encode(result, output);

--- a/src/tests/unit/fixtures/thrift-server/throws_service.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/throws_service.solution.ts
@@ -600,7 +600,7 @@ export class Processor<Context = any> extends thrift.ThriftProcessor<Context, IH
                 return output.flush();
             }
             else {
-                console.error("Unexpected exception while handling peg: ", err);
+                console.error("Unexpected exception while handling peg:", err);
                 const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
                 output.writeMessageBegin("peg", thrift.MessageType.EXCEPTION, requestId);
                 thrift.TApplicationExceptionCodec.encode(result, output);
@@ -626,7 +626,7 @@ export class Processor<Context = any> extends thrift.ThriftProcessor<Context, IH
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
-            console.error("Unexpected exception while handling pong: ", err);
+            console.error("Unexpected exception while handling pong:", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, "The server experienced an unexpected exception while processing the request.");
             output.writeMessageBegin("pong", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);


### PR DESCRIPTION
Paul and Buck: Don't feel a lot of pressure to review this thoroughly. I don't think I need an approval to do the merge. I'm mostly just including you in my changes so someone other than me is aware of what I'm doing.

There was a small problem with my first attempt at https://github.com/StatesTitle/thrift-typescript/tree/mdoliner-st/Add_server_side_logging_of_non-thrift_exceptions, which is that I had a space at the end of my log message. This space isn't needed because console.log() automatically adds a space between parameters. I removed it in a follow-up commit on that branch. This commit makes that same change to our all_states_title_changes branch. Because our branch has a few branches merged into it the whitespace commit has almost 100% conflicts. It was easier for me to just re-do the change on this branch rather than try to merge the //github.com/StatesTitle/thrift-typescript/tree/mdoliner-st/Add_server_side_logging_of_non-thrift_exceptions branch again and deal with the merge conflicts.